### PR TITLE
Adds support for term weights when indexing

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,7 @@
+=== Unreleased
+
+* Support for custom term weights when indexing
+
 === 1.4.0 (13th March 2012)
 
 * Support for indexing Arrays properly

--- a/README.rdoc
+++ b/README.rdoc
@@ -160,6 +160,20 @@ And any combinations of the above:
 
   db.search("(ruby OR sinatra) -rails xap*")
 
+== Custom term weights
+
+Sometimes you may want to increase the weight of a particular term in
+a document. Xapian supports adding
+{extra weight}(http://trac.xapian.org/wiki/FAQ/ExtraWeight) to a term
+at index time by providing an integer "wdf" (default is 1).
+
+You may set an optional :weights option when initializing a XapianDb.
+The :weights option accepts a Proc or Lambda that will be called with
+the key, value and list of document fields as each term is indexed.
+Your function should return an integer to set the weight to.
+
+  XapianDb.new(:weights => lambda {|k, v, f| k == :title ? 3 : 1}
+
 == Boolean terms
 
 If you want to implement something like [this](http://getting-started-with-xapian.readthedocs.org/en/latest/howtos/boolean_filters.html#searching),

--- a/lib/xapian_fu/xapian_doc.rb
+++ b/lib/xapian_fu/xapian_doc.rb
@@ -275,10 +275,12 @@ module XapianFu #:nodoc:
         else
           v = v.to_s
         end
+        # get the custom term weight if a weights function exists
+        weight = db.weights_function ? db.weights_function.call(k, v, fields).to_i : 1
         # add value with field name
-        tg.send(index_method, v, 1, 'X' + k.to_s.upcase)
+        tg.send(index_method, v, weight, 'X' + k.to_s.upcase)
         # add value without field name
-        tg.send(index_method, v)
+        tg.send(index_method, v, weight)
       end
 
       db.boolean_fields.each do |name|


### PR DESCRIPTION
Xapian supports adding extra weight to certain terms as part of the
indexing process.

This commit adds a :weights option to XapianDb.new which takes a
function that returns an integer weight value for the given key and
value. This weight value is then passed to the TermGenerator as part
of the index_text process.

If a weights function isn't provided, the current default of 1 is
passed instead.
