### PR TITLE
Return a `nil` rather than `false` stopper

### DIFF
--- a/lib/xapian_fu/stopper_factory.rb
+++ b/lib/xapian_fu/stopper_factory.rb
@@ -9,7 +9,7 @@ module XapianFu
       case lang
       when Xapian::Stopper
         lang
-      when false
+      when false, nil
         nil
       else
         lang = lang.to_s.downcase.strip

--- a/lib/xapian_fu/stopper_factory.rb
+++ b/lib/xapian_fu/stopper_factory.rb
@@ -10,7 +10,7 @@ module XapianFu
       when Xapian::Stopper
         lang
       when false
-        false
+        nil
       else
         lang = lang.to_s.downcase.strip
         if @stoppers[lang]


### PR DESCRIPTION
With the latest Xapian (1.2.15.1) a `false` stopper raises:

```
ArgumentError: Wrong arguments for overloaded method 'QueryParser.stopper='.
Possible C/C++ prototypes are:
    void QueryParser.stopper=(Xapian::Stopper const *stop)
    void QueryParser.stopper=()

    from /Users/garry/.rvm/gems/ruby-2.0.0-p247@mediagreenhouse/bundler/gems/xapian-fu-23859675dcbc/lib/xapian_fu/query_parser.rb:100:in `stopper='
    from /Users/garry/.rvm/gems/ruby-2.0.0-p247@mediagreenhouse/bundler/gems/xapian-fu-23859675dcbc/lib/xapian_fu/query_parser.rb:100:in `query_parser'
    from /Users/garry/.rvm/gems/ruby-2.0.0-p247@mediagreenhouse/bundler/gems/xapian-fu-23859675dcbc/lib/xapian_fu/query_parser.rb:84:in `parse_query'
    from /Users/garry/.rvm/gems/ruby-2.0.0-p247@mediagreenhouse/bundler/gems/xapian-fu-23859675dcbc/lib/xapian_fu/xapian_db.rb:270:in `search'
```
