### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,11 @@ branches:
     - master
 
 rvm:
-  - 1.8.7
   - 1.9.3
-
-gemfile:
-  - .travis/Gemfile
-
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq libxapian22 libxapian-dev
- - wget https://gist.github.com/raw/4486398/31a002b6c9eef194ad7d2d55317e8a14d7ca2ad6/install.sh -O /tmp/xapian-bindings.sh
- - sudo bash /tmp/xapian-bindings.sh
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6

--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -1,3 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path => "../"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :test do
+  gem "xapian-ruby", "~> 1.2.22"
+end


### PR DESCRIPTION
Have travis use xapian-ruby gem bindings

And ditch 1.8.7 tests too while we're here.

